### PR TITLE
fixes typo : "retrive" should be "retrieve"

### DIFF
--- a/GDrive/GDrive/src/main/java/org/jboss/aerogear/android/example/gdrive/MainActivity.java
+++ b/GDrive/GDrive/src/main/java/org/jboss/aerogear/android/example/gdrive/MainActivity.java
@@ -56,7 +56,7 @@ public class MainActivity extends ActionBarActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (authzModule.isAuthorized()) {
-            retriveFiles();
+            retrieveFiles();
         } else {
             authz();
         }
@@ -82,7 +82,7 @@ public class MainActivity extends ActionBarActivity {
                 @Override
                 public void onSuccess(String o) {
                     Log.d("TOKEN ++ ", o);
-                    retriveFiles();
+                    retrieveFiles();
                 }
 
                 @Override
@@ -98,7 +98,7 @@ public class MainActivity extends ActionBarActivity {
         }
     }
 
-    private void retriveFiles() {
+    private void retrieveFiles() {
 
         displayLoading();
 


### PR DESCRIPTION
This fixes a typo in the code example. Changes "Retrive" to "Retrieve"